### PR TITLE
fix: error on missing image description

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -52,10 +52,7 @@ async fn sync_statuses(env: &Env) -> Result<HashMap<String, String>, Box<dyn Err
           let id = match twitter::upload_image(
             &twitter_auth,
             attachment.url.as_str(),
-            match attachment.description.is_empty() {
-              true => None,
-              false => Some(attachment.description.as_str()),
-            },
+            attachment.description.as_deref(),
           )
           .await
           {

--- a/src/mastodon.rs
+++ b/src/mastodon.rs
@@ -72,7 +72,7 @@ pub struct Status {
 pub struct MediaAttachment {
   pub id: String,
   pub url: String,
-  pub description: String,
+  pub description: Option<String>,
 }
 
 // Environment


### PR DESCRIPTION
画像の alt-text が存在しない場合に、投稿に失敗する問題を修正する。