### PR TITLE
chore(deps-dev): pin dev-dependency version

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "lint": "cargo clippy --release"
   },
   "devDependencies": {
-    "esbuild": "^0.24.0",
-    "wrangler": "^3.91.0"
+    "esbuild": "0.24.0",
+    "wrangler": "3.91.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "masto-to-tw",
   "description": "Sync Mastodon posts to Twitter.",
   "private": "true",
-  "packageManager": "pnpm@9.12.1",
+  "packageManager": "pnpm@9.14.4",
   "scripts": {
     "build": "wrangler deploy --dry-run",
     "deploy": "wrangler deploy",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,10 +9,10 @@ importers:
   .:
     devDependencies:
       esbuild:
-        specifier: ^0.24.0
+        specifier: 0.24.0
         version: 0.24.0
       wrangler:
-        specifier: ^3.91.0
+        specifier: 3.91.0
         version: 3.91.0
 
 packages:


### PR DESCRIPTION
- Pin the dev-dependency version completely.
- Bump package manager `pnpm` version to `9.14.4`.