### PR TITLE
chore(deps): fix dependabot issues

### DIFF
--- a/.github/actions/setup-pnpm/action.yaml
+++ b/.github/actions/setup-pnpm/action.yaml
@@ -17,7 +17,7 @@ runs:
 
   steps:
     - name: Setup pnpm
-      uses: pnpm/action-setup@v4.1.0
+      uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda # v4.1.0
       with:
         run_install: false
 
@@ -29,7 +29,7 @@ runs:
         echo "STORE_PATH=$(pnpm store path)" >> ${GITHUB_OUTPUT}
 
     - name: Setup dependencies cache
-      uses: actions/cache@v4.2.3
+      uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
       with:
         path: ${{ steps.pnpm-config.outputs.STORE_PATH }}
         key: pnpm-cache-${{ inputs.cache-prefix }}-${{ hashFiles(format('{0}/pnpm-lock.yaml', inputs.cwd)) }}

--- a/.github/actions/setup-rust/action.yaml
+++ b/.github/actions/setup-rust/action.yaml
@@ -23,7 +23,7 @@ runs:
         target: ${{ env.RUST_TOOLCHAIN_TARGET }}
 
     - name: Setup rust dependencies cache
-      uses: Swatinem/rust-cache@v2.7.8
+      uses: Swatinem/rust-cache@9d47c6ad4b02e050fd481d890b2ea34778fd09d6 # v2.7.8
       with:
         prefix-key: rust-cache-${{ inputs.cache-prefix }}
         shared-key: ${{ hashFiles(format('{0}/Cargo.lock', inputs.cwd)) }}

--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -3,7 +3,8 @@ version: 2
 updates:
   # Cargo crates
   - package-ecosystem: "cargo"
-    directory: "/"
+    directories:
+      - "/"
     schedule:
       interval: "monthly"
       time: "03:00"
@@ -18,7 +19,8 @@ updates:
 
     # node.js modules
   - package-ecosystem: "npm"
-    directory: "/"
+    directories:
+      - "/"
     schedule:
       interval: "monthly"
       time: "03:00"
@@ -35,8 +37,7 @@ updates:
   # Terraform functions
   - package-ecosystem: "terraform"
     directories:
-      - "/terraform/kv"
-      - "/terraform/secrets"
+      - "/terraform/**/*"
     schedule:
       interval: "monthly"
       time: "03:00"
@@ -50,33 +51,9 @@ updates:
 
   # GitHub Actions
   - package-ecosystem: "github-actions"
-    directory: "/"
-    schedule:
-      interval: "monthly"
-      time: "03:00"
-      timezone: "Asia/Tokyo"
-    labels:
-      - "Type: CI"
-      - "Type: Dependencies"
-    assignees:
-      - "RShirohara"
-    reviewers:
-      - "RShirohara"
-  - package-ecosystem: "github-actions"
-    directory: "/.github/actions/setup-pnpm"
-    schedule:
-      interval: "monthly"
-      time: "03:00"
-      timezone: "Asia/Tokyo"
-    labels:
-      - "Type: CI"
-      - "Type: Dependencies"
-    assignees:
-      - "RShirohara"
-    reviewers:
-      - "RShirohara"
-  - package-ecosystem: "github-actions"
-    directory: "/.github/actions/setup-rust"
+    directories:
+      - "/"
+      - "/.github/actions/*"
     schedule:
       interval: "monthly"
       time: "03:00"

--- a/.github/workflows/ci-action.yaml
+++ b/.github/workflows/ci-action.yaml
@@ -22,7 +22,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4.2.2
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Setup actionlint
         env:
@@ -39,7 +39,7 @@ jobs:
               "${ACTIONLINT_INSTALL_DIR}"
 
       - name: Setup reviewdog
-        uses: reviewdog/action-setup@v1.3.2
+        uses: reviewdog/action-setup@e04ffabe3898a0af8d0fb1af00c188831c4b5893 # v1.3.2
 
       - name: Run actionlint
         env:

--- a/.github/workflows/ci-cargo.yaml
+++ b/.github/workflows/ci-cargo.yaml
@@ -26,7 +26,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4.2.2
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Setup rust
         uses: ./.github/actions/setup-rust
@@ -49,7 +49,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4.2.2
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Setup rust
         uses: ./.github/actions/setup-rust
@@ -58,7 +58,7 @@ jobs:
         uses: ./.github/actions/setup-pnpm
 
       - name: Setup reviewdog
-        uses: reviewdog/action-setup@v1.3.2
+        uses: reviewdog/action-setup@e04ffabe3898a0af8d0fb1af00c188831c4b5893 # v1.3.2
 
       - name: Run clippy
         env:
@@ -85,7 +85,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4.2.2
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Setup rust
         uses: ./.github/actions/setup-rust

--- a/.github/workflows/cleanup-cache.yaml
+++ b/.github/workflows/cleanup-cache.yaml
@@ -15,7 +15,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4.2.2
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Setup gh-actions-cache
         env:


### PR DESCRIPTION
- Change property `directory` to `directories` for dependabot config and use glob pattern on `directories` property.
- Pin version for GitHub Actions workflow dependency.