### PR TITLE
fix: build failure due to wasm-pack `bulk-memory` option not enabled

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,3 +24,6 @@ opt-level = "s"
 lto = true
 strip = true
 codegen-units = 1
+
+[package.metadata.wasm-pack.profile.release]
+wasm-opt = ["--enable-bulk-memory", "--enable-nontrapping-float-to-int"]


### PR DESCRIPTION
Source: https://github.com/rustwasm/wasm-pack/issues/1441#issuecomment-2886461752